### PR TITLE
Improve i18n of plist files

### DIFF
--- a/InAppSettingsKit.podspec
+++ b/InAppSettingsKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name                  = 'InAppSettingsKit'
-	s.version               = '2.9.2'
+	s.version               = '2.9.3'
 	s.summary               = 'This iPhone framework allows settings to be in-app in addition to being in the Settings app.'
 	s.authors               = {"Ortwin Gentz" => "http://www.futuretap.com", "Luc Vandal" => "http://edovia.com/company/#contact_form"}
 	s.social_media_url		= "https://twitter.com/IASettingsKit"

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -654,7 +654,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	} else if ([specifier.type isEqualToString:kIASKButtonSpecifier]) {
 		NSString *value = [self.settingsStore objectForKey:specifier.key];
         // TODO: support BundleTable
-		cell.textLabel.text = ([value isKindOfClass:NSString.class] && [self.settingsReader titleForId:value fromBundleTable:nil].length) ? [self.settingsReader titleForId:value fromBundleTable:nil] : specifier.title;
+        cell.textLabel.text = ([value isKindOfClass:NSString.class] && [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil].length) ? [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil] : specifier.title;
 		cell.detailTextLabel.text = specifier.subtitle;
 		IASK_IF_IOS7_OR_GREATER
 		(if (specifier.textAlignment != NSTextAlignmentLeft) {
@@ -665,7 +665,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	} else if ([specifier.type isEqualToString:kIASKPSRadioGroupSpecifier]) {
 		NSInteger index = [specifier.multipleValues indexOfObject:specifier.radioGroupValue];
         // TODO: support BundleTable
-		cell.textLabel.text = [self.settingsReader titleForId:specifier.multipleTitles[index] fromBundleTable:nil];
+        cell.textLabel.text = [self.settingsReader titleForId:specifier.multipleTitles[index] withDefaultValue:nil fromBundleTable:nil];
 		[_selections[indexPath.section] updateSelectionInCell:cell indexPath:indexPath];
 	} else {
 		cell.textLabel.text = specifier.title;

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -653,8 +653,8 @@ CGRect IASKCGRectSwap(CGRect rect);
 		cell.accessoryType = (specifier.textAlignment == NSTextAlignmentLeft) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
 	} else if ([specifier.type isEqualToString:kIASKButtonSpecifier]) {
 		NSString *value = [self.settingsStore objectForKey:specifier.key];
-        // TODO: support BundleTable
-        cell.textLabel.text = ([value isKindOfClass:NSString.class] && [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil].length) ? [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil] : specifier.title;
+		// TODO: support BundleTable
+		cell.textLabel.text = ([value isKindOfClass:NSString.class] && [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil].length) ? [self.settingsReader titleForId:value withDefaultValue:nil fromBundleTable:nil] : specifier.title;
 		cell.detailTextLabel.text = specifier.subtitle;
 		IASK_IF_IOS7_OR_GREATER
 		(if (specifier.textAlignment != NSTextAlignmentLeft) {
@@ -664,8 +664,19 @@ CGRect IASKCGRectSwap(CGRect rect);
 		cell.accessoryType = (specifier.textAlignment == NSTextAlignmentLeft) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
 	} else if ([specifier.type isEqualToString:kIASKPSRadioGroupSpecifier]) {
 		NSInteger index = [specifier.multipleValues indexOfObject:specifier.radioGroupValue];
-        // TODO: support BundleTable
-        cell.textLabel.text = [self.settingsReader titleForId:specifier.multipleTitles[index] withDefaultValue:nil fromBundleTable:nil];
+
+		NSString *titleId = nil, *titleDefault = nil, *bundleTable = nil;
+
+		if ([specifier.multipleTitles[index] isKindOfClass:[NSString class]]) {
+			titleId = specifier.multipleTitles[index];
+		}
+		else {
+			titleId = [specifier.multipleTitles[index] valueForKey:kIASKTitle];
+			titleDefault = [specifier.multipleTitles[index] valueForKey:kIASKTitleDefault];
+			bundleTable = [specifier.multipleTitles[index] valueForKey:kIASKBundleTable];
+		}
+
+		cell.textLabel.text = [self.settingsReader titleForId:titleId withDefaultValue:titleDefault fromBundleTable:bundleTable];
 		[_selections[indexPath.section] updateSelectionInCell:cell indexPath:indexPath];
 	} else {
 		cell.textLabel.text = specifier.title;
@@ -680,7 +691,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	cell.detailTextLabel.textAlignment = specifier.textAlignment;
 	cell.textLabel.adjustsFontSizeToFitWidth = specifier.adjustsFontSizeToFitWidth;
 	cell.detailTextLabel.adjustsFontSizeToFitWidth = specifier.adjustsFontSizeToFitWidth;
-    return cell;
+	return cell;
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -125,7 +125,7 @@
 
     @try {
         // TODO: support BundleTable
-		[[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row] fromBundleTable:nil]];
+        [[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row] withDefaultValue:nil fromBundleTable:nil]];
 	}
 	@catch (NSException * e) {}
     return cell;

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -124,8 +124,18 @@
     [_selection updateSelectionInCell:cell indexPath:indexPath];
 
     @try {
-        // TODO: support BundleTable
-        [[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row] withDefaultValue:nil fromBundleTable:nil]];
+        NSString *titleId = nil, *titleDefault = nil, *bundleTable = nil;
+
+        if ([[titles objectAtIndex:indexPath.row] isKindOfClass:[NSString class]]) {
+            titleId = [titles objectAtIndex:indexPath.row];
+        }
+        else {
+            titleId = [[titles objectAtIndex:indexPath.row] valueForKey:kIASKTitle];
+            titleDefault = [[titles objectAtIndex:indexPath.row] valueForKey:kIASKTitleDefault];
+            bundleTable = [[titles objectAtIndex:indexPath.row] valueForKey:kIASKBundleTable];
+        }
+
+        [[cell textLabel] setText:[self.settingsReader titleForId:titleId withDefaultValue:titleDefault fromBundleTable:bundleTable]];
 	}
 	@catch (NSException * e) {}
     return cell;

--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -23,7 +23,9 @@
 #define kIASKBundleTable                      @"BundleTable"
 #define kIASKType                             @"Type"
 #define kIASKTitle                            @"Title"
+#define kIASKTitleDefault                     @"TitleDefault"
 #define kIASKFooterText                       @"FooterText"
+#define kIASKFooterTextDefault                @"FooterTextDefault"
 #define kIASKKey                              @"Key"
 #define kIASKFile                             @"File"
 #define kIASKDefaultValue                     @"DefaultValue"
@@ -41,7 +43,9 @@
 #define kIASKShortTitles                      @"ShortTitles"
 #define kIASKSupportedUserInterfaceIdioms     @"SupportedUserInterfaceIdioms"
 #define kIASKSubtitle                         @"IASKSubtitle"
+#define kIASKSubtitleDefault                  @"IASKSubtitleDefault"
 #define kIASKPlaceholder                      @"IASKPlaceholder"
+#define kIASKPlaceholderDefault               @"IASKPlaceholderDefault"
 #define kIASKViewControllerClass              @"IASKViewControllerClass"
 #define kIASKViewControllerSelector           @"IASKViewControllerSelector"
 #define kIASKViewControllerStoryBoardFile     @"IASKViewControllerStoryBoardFile"
@@ -234,7 +238,7 @@ __VA_ARGS__ \
 - (NSString*)titleForSection:(NSInteger)section;
 - (NSString*)keyForSection:(NSInteger)section;
 - (NSString*)footerTextForSection:(NSInteger)section;
-- (NSString*)titleForId:(NSObject*)titleId fromBundleTable:(NSString*)bundleTable;
+- (NSString*)titleForId:(NSObject*)titleId withDefaultValue:(NSString*)titleValue fromBundleTable:(NSString*)bundleTable;
 - (NSString*)pathForImageNamed:(NSString*)image;
 
 + (NSBundle*)bundleFromName:(NSString*)bundleName;

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -238,7 +238,7 @@
 }
 
 - (NSString*)titleForSection:(NSInteger)section {
-    return [self titleForId:[self headerSpecifierForSection:section].title withDefaultValue:[self headerSpecifierForSection:section].titleDefault fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
+    return [self headerSpecifierForSection:section].title;
 }
 
 - (NSString*)keyForSection:(NSInteger)section {
@@ -246,7 +246,7 @@
 }
 
 - (NSString*)footerTextForSection:(NSInteger)section {
-    return [self titleForId:[self headerSpecifierForSection:section].footerText withDefaultValue:[self headerSpecifierForSection:section].footerTextDefault fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
+    return [self headerSpecifierForSection:section].footerText;
 }
 
 - (NSString*)titleForId:(NSObject*)titleId withDefaultValue:(NSString*)titleValue fromBundleTable:(NSString*)bundleTable
@@ -259,6 +259,10 @@
 	}
 	else
 	{
+        if (titleId == nil) {
+            return nil;
+        }
+        
 		NSString* stringTitleId = (NSString*)titleId;
 
         if (!titleValue) {
@@ -320,7 +324,11 @@
     if (bundlePath == nil) {
         // HACK: In the Example app, the PsiphonClientCommonLibrary is sometimes seemingly not findable when the app starts via pathForResource. So we'll also try to get it via bundleForIdentifier.
         NSString *bundleIdentifier = [NSString stringWithFormat:@"org.cocoapods.%@", bundleName];
-        bundlePath = [[NSBundle bundleWithIdentifier:bundleIdentifier] pathForResource:bundleName ofType:@"bundle"];
+        bundle = [NSBundle bundleWithIdentifier:bundleIdentifier];
+        bundlePath = [bundle pathForResource:bundleName ofType:@"bundle"];
+        if (bundlePath == nil) {
+            bundlePath = bundle.bundlePath;
+        }
     }
 
     if (bundlePath != nil) {

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -238,7 +238,7 @@
 }
 
 - (NSString*)titleForSection:(NSInteger)section {
-    return [self titleForId:[self headerSpecifierForSection:section].title fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
+    return [self titleForId:[self headerSpecifierForSection:section].title withDefaultValue:[self headerSpecifierForSection:section].titleDefault fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
 }
 
 - (NSString*)keyForSection:(NSInteger)section {
@@ -246,10 +246,10 @@
 }
 
 - (NSString*)footerTextForSection:(NSInteger)section {
-    return [self titleForId:[self headerSpecifierForSection:section].footerText fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
+    return [self titleForId:[self headerSpecifierForSection:section].footerText withDefaultValue:[self headerSpecifierForSection:section].footerTextDefault fromBundleTable:[self headerSpecifierForSection:section].bundleTable];
 }
 
-- (NSString*)titleForId:(NSObject*)titleId fromBundleTable:(NSString*)bundleTable
+- (NSString*)titleForId:(NSObject*)titleId withDefaultValue:(NSString*)titleValue fromBundleTable:(NSString*)bundleTable
 {
 	if([titleId isKindOfClass:[NSNumber class]]) {
 		NSNumber* numberTitleId = (NSNumber*)titleId;
@@ -260,6 +260,12 @@
 	else
 	{
 		NSString* stringTitleId = (NSString*)titleId;
+
+        if (!titleValue) {
+            // Not all plist entries will have a default value. In particular,
+            // items that are not intended to be translated.
+            titleValue = stringTitleId;
+        }
 
         NSBundle* bundle = self.settingsBundle;
         NSString* stringTable = self.localizationTable;
@@ -294,7 +300,7 @@
             }
         }
 
-        return [bundle localizedStringForKey:stringTitleId value:stringTitleId table:stringTable];
+        return [bundle localizedStringForKey:stringTitleId value:titleValue table:stringTable];
 	}
 }
 

--- a/InAppSettingsKit/Models/IASKSpecifier.h
+++ b/InAppSettingsKit/Models/IASKSpecifier.h
@@ -34,8 +34,11 @@
 - (NSString*)localizedObjectForKey:(NSString*)key;
 - (NSString *)bundleTable;
 - (NSString *)title;
+- (NSString *)titleDefault;
 - (NSString*)subtitle;
+- (NSString*)subtitleDefault;
 - (NSString*)placeholder;
+- (NSString*)placeholderDefault;
 - (NSString*)key;
 - (NSString*)type;
 - (NSString*)titleForCurrentValue:(id)currentValue;
@@ -58,6 +61,7 @@
 - (UITextAutocapitalizationType)autocapitalizationType;
 - (UITextAutocorrectionType)autoCorrectionType;
 - (NSString*)footerText;
+- (NSString*)footerTextDefault;
 - (Class)viewControllerClass;
 - (SEL)viewControllerSelector;
 - (NSString*)viewControllerStoryBoardFile;

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -271,8 +271,19 @@
 	}
 	@try {
 		IASKSettingsReader *strongSettingsReader = self.settingsReader;
-        // TODO: support BundleTable
-        return [strongSettingsReader titleForId:[titles objectAtIndex:keyIndex] withDefaultValue:nil fromBundleTable:nil];
+
+        NSString *titleId = nil, *titleDefault = nil, *bundleTable = nil;
+
+        if ([[titles objectAtIndex:keyIndex] isKindOfClass:[NSString class]]) {
+            titleId = [titles objectAtIndex:keyIndex];
+        }
+        else {
+            titleId = [[titles objectAtIndex:keyIndex] valueForKey:kIASKTitle];
+            titleDefault = [[titles objectAtIndex:keyIndex] valueForKey:kIASKTitleDefault];
+            bundleTable = [[titles objectAtIndex:keyIndex] valueForKey:kIASKBundleTable];
+        }
+
+        return [strongSettingsReader titleForId:titleId withDefaultValue:titleDefault fromBundleTable:bundleTable];
 	}
 	@catch (NSException * e) {}
 	return nil;

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -96,7 +96,7 @@
         IASKSettingsReader *strongSettingsReader = self.settingsReader;
         [titles enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             // TODO: support BundleTable
-            NSString *localizedTitle = [strongSettingsReader titleForId:obj fromBundleTable:nil];
+            NSString *localizedTitle = [strongSettingsReader titleForId:obj withDefaultValue:nil fromBundleTable:nil];
             [temporaryMappingsForSort addObject:@{titleKey : obj,
                                                   valueKey : values[idx],
                                                   localizedTitleKey : localizedTitle,
@@ -153,7 +153,12 @@
 
 - (NSString*)localizedObjectForKey:(NSString*)key {
 	IASKSettingsReader *settingsReader = self.settingsReader;
-	return [settingsReader titleForId:[_specifierDict objectForKey:key] fromBundleTable:self.bundleTable];
+
+    // This is kind of a hack to go from something like "FooterText" to "FooterTextDefault".
+    // It will fail for some keys, but nil is okay in those cases okay.
+    NSString* defaultValueKey = [key stringByAppendingString:@"Default"];
+
+    return [settingsReader titleForId:[_specifierDict objectForKey:key] withDefaultValue:[_specifierDict objectForKey:defaultValueKey] fromBundleTable:self.bundleTable];
 }
 
 - (NSString*)bundleTable {
@@ -166,16 +171,40 @@
     return [self localizedObjectForKey:kIASKTitle];
 }
 
+- (NSString*)titleDefault {
+    // localizedObjectForKey tries to localize, which we don't want here, so we're accessing the specifier dict directly
+    NSString* res = [_specifierDict objectForKey:kIASKTitleDefault];
+    return res;
+}
+
 - (NSString*)subtitle {
 	return [self localizedObjectForKey:kIASKSubtitle];
 }
 
+- (NSString*)subtitleDefault {
+    // localizedObjectForKey tries to localize, which we don't want here, so we're accessing the specifier dict directly
+    NSString* res = [_specifierDict objectForKey:kIASKSubtitleDefault];
+    return res;
+}
+
 - (NSString *)placeholder {
+    // localizedObjectForKey tries to localize, which we don't want here, so we're accessing the specifier dict directly
+    NSString* res = [_specifierDict objectForKey:kIASKPlaceholderDefault];
+    return res;
+}
+
+- (NSString *)placeholderDefault {
     return [self localizedObjectForKey:kIASKPlaceholder];
 }
 
 - (NSString*)footerText {
     return [self localizedObjectForKey:kIASKFooterText];
+}
+
+- (NSString*)footerTextDefault {
+    // localizedObjectForKey tries to localize, which we don't want here, so we're accessing the specifier dict directly
+    NSString* res = [_specifierDict objectForKey:kIASKFooterTextDefault];
+    return res;
 }
 
 - (Class)viewControllerClass {
@@ -243,7 +272,7 @@
 	@try {
 		IASKSettingsReader *strongSettingsReader = self.settingsReader;
         // TODO: support BundleTable
-		return [strongSettingsReader titleForId:[titles objectAtIndex:keyIndex] fromBundleTable:nil];
+        return [strongSettingsReader titleForId:[titles objectAtIndex:keyIndex] withDefaultValue:nil fromBundleTable:nil];
 	}
 	@catch (NSException * e) {}
 	return nil;


### PR DESCRIPTION
String keys, defaults, and descriptions are now in plists. Plist files are now the canonical source for all strings, and `Root.strings` should be derived from them.